### PR TITLE
fix: symfony deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.1",
         "symfony/config": "^6.1",
         "symfony/dependency-injection": "^6.1",
-        "symfony/framework-bundle": "^6.2",
+        "symfony/framework-bundle": "^6.1",
         "symfony/http-kernel": "^6.1",
         "symfony/string": "^6.1"
     },
@@ -45,6 +45,11 @@
             "composer/package-versions-deprecated": true,
             "symfony/flex": true,
             "symfony/runtime": true
+        }
+    },
+    "extra": {
+        "symfony": {
+            "require": "^6.1"
         }
     }
 }


### PR DESCRIPTION
# Fix symfony deps

## Description

All symfony deps based on same version

## Motivation and context

easyblue/rules-engine version 1.0.1 not used on projects based on symfony <= 6.1

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
